### PR TITLE
Check step_by_unchecked for u29 integer overflow

### DIFF
--- a/recapn/src/ptr.rs
+++ b/recapn/src/ptr.rs
@@ -1965,6 +1965,8 @@ unsafe fn iter_unchecked(place: SegmentRef<'_>, offset: SegmentOffset) -> impl I
 
 #[inline]
 unsafe fn step_by_unchecked(place: SegmentRef<'_>, offset: SegmentOffset, len: SegmentOffset) -> impl Iterator<Item = SegmentRef<'_>> {
+    assert!(offset.get().checked_mul(len.get()).is_some_and(|size| size <= SegmentOffset::MAX_VALUE));
+
     let range = 0..len.get();
     range.into_iter().map(move |idx| unsafe {
         let new_offset = SegmentOffset::new_unchecked(offset.get() * idx);


### PR DESCRIPTION
I'm not sure how much verification callers perform, but integer overflow in the multiplication of pointer offsets is a classic C-style unsafety, so I think it's better to check for it anyway.